### PR TITLE
Event detail page updates

### DIFF
--- a/eventPlanner/planner/templates/browseEvents.html
+++ b/eventPlanner/planner/templates/browseEvents.html
@@ -17,14 +17,16 @@
   <div class="columns is-multiline">
     {% for event in events %}
     <div class="column is-one-third">
-      <div class="box">
-        <p class="title">{{event.name}}</p>
-        <div class="tags">
-          <span class="tag">{{event.location}}</span>
+      <a href = {% url "event" event.id%}> 
+        <div class="box">
+          <p class="title">{{event.name}}</p>
+          <div class="tags">
+            <span class="tag">{{event.location}}</span>
+          </div>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor
+            vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.</p>
         </div>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor
-          vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.</p>:
-      </div>
+      </a>
     </div>
     {% endfor %}
   </div>

--- a/eventPlanner/planner/templates/eventDetail.html
+++ b/eventPlanner/planner/templates/eventDetail.html
@@ -8,7 +8,7 @@
             <div class="container">
             <h1 class="title">
               <i class="fa-solid fa-book"></i>
-              Event Name
+              {{event.name}}
             </h1>
             <h2 class="subtitle">
                 Here are the details for your event!
@@ -18,22 +18,22 @@
     </section>
     
     <div class="container is-fluid">
-        <h1 class="title">Event Host</h1>
-        <h2 class="subtitle ml-3">Event Host name here</h2>
+        <h1 class="title">Host</h1>
+        <h2 class="subtitle ml-3">Event Host</h2>
        
-        <h1 class="title">Event Location</h1>
-        <h2 class="subtitle ml-3">Event Location name here</h2>
+        <h1 class="title">Location</h1>
+        <h2 class="subtitle ml-3">{{event.location}}</h2>
 
-        <h1 class="title">Event Date</h1>
-        <h2 class="subtitle ml-3">Event Date name here</h2>
+        <h1 class="title">Date</h1>
+        <h2 class="subtitle ml-3">{{event.date}}</h2>
 
-        <h1 class="title">Event Time</h1>
-        <h2 class="subtitle ml-3">Event Time  here</h2>
+        <h1 class="title">Time</h1>
+        <h2 class="subtitle ml-3">{{event.time}}</h2>
 
-        <h1 class="title">Event Description</h1>
-        <h2 class="subtitle ml-3">Event Description  here</h2>
+        <h1 class="title">Description</h1>
+        <h2 class="subtitle ml-3">Event Description</h2>
 
-        <h1 class="title">Needed Tasks</h1>
+        <h1 class="title">Tasks</h1>
         <h2 class="subtitle ml-3">Needed Tasks here</h2>
 
         <button class="button ml-3">RSVP</button>

--- a/eventPlanner/planner/urls.py
+++ b/eventPlanner/planner/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path('events/', views.events, name = 'events'),
 
     #this need to be changed later to event/<int:event_id>, but for now it is just eventDetail because we don't have the database setup yet
-    path('eventDetail', views.event, name = 'event'),  
+    path('event/<int:id>', views.event, name = 'event'),  
 
     path('createEvent', views.createEvent, name = 'createEvent'),
 ]

--- a/eventPlanner/planner/views.py
+++ b/eventPlanner/planner/views.py
@@ -1,5 +1,6 @@
-from django.shortcuts import render, HttpResponse
+from django.shortcuts import render, HttpResponse, redirect
 from .models import Event
+from django.http import Http404
 
 
 # Create your views here.
@@ -16,8 +17,15 @@ def events(request):
     return render(request, 'browseEvents.html', context)
 
 #event detail view: viewing a specific event
-def event(request):
-    return render(request, 'eventDetail.html')
+def event(request, id):
+    try: 
+        event = Event.objects.get(id=id)
+    except Event.DoesNotExist:
+        return redirect('events')
+    
+    context = {'event': event}
+    
+    return render(request, 'eventDetail.html', context)
 
 def createEvent(request):
     return render(request, 'createEvent.html')


### PR DESCRIPTION
Linked each card in the browse events page to a specific event detail page. Did this by modifying the events detail page to take an id as an argument from the url and return the context for the event with that id. One should now be able to click on an event in the browse events page and be directed to the events detail page for that event. 

Side Note: Right now the event detail page looks somewhat plain, so at some point, someone should change it to look more interesting. (Low priority)