### PR TITLE
Implementing a Delete Event Functionality

### DIFF
--- a/eventPlanner/eventPlanner/settings.py
+++ b/eventPlanner/eventPlanner/settings.py
@@ -78,10 +78,10 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'eventPlanner',
-        'USER': 'django',
-        'PASSWORD': 'password',
+        'USER': 'django', 
+        'PASSWORD': 'password',  
         'HOST': 'localhost',
-        'PORT': '',
+        'PORT': '',   #3306
     }
 }
 

--- a/eventPlanner/planner/templates/base.html
+++ b/eventPlanner/planner/templates/base.html
@@ -5,7 +5,7 @@
   {% load static %}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Create Event</title>
+  <title>{% block title %}{%endblock %}Create Event</title>
   {% load static %}
   <link rel="stylesheet" href="{% static 'bulma/css/bulma.css' %}">
   {% load static %}

--- a/eventPlanner/planner/templates/browseEvents.html
+++ b/eventPlanner/planner/templates/browseEvents.html
@@ -1,7 +1,14 @@
 {% extends "loggedInBase.html" %}
 
 {% block content %}
-
+<!-- Flash message  -->
+{% if messages %}
+{% for message in messages %}
+<div class="">
+<p class="">{{message}}</p>
+</div>
+{% endfor %}
+{% endif %}
 <section class="hero is-primary">
   <div class="hero-body">
     <div class="container">

--- a/eventPlanner/planner/templates/eventDetail.html
+++ b/eventPlanner/planner/templates/eventDetail.html
@@ -50,7 +50,10 @@
             <p class="m-2"> <i class="fa-regular fa-clock"></i> {{event.date}} at {{event.time}}</p>
 
             <p class="m-2"> {{event.description}}</p>
-            
+            <!-- DELETE EVENT -->
+            <div class="">
+                <a href="{% url 'delete-event' event.id %}" class="">Delete</a>
+            </div>
             <div class="title m-2">Sign up for a task!
             <div class="control">
                 <div  id = "tasks" class="is-one-fifth">

--- a/eventPlanner/planner/templates/event_confirm_delete.html
+++ b/eventPlanner/planner/templates/event_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block title %}
+{{event.name}}|
+{% endblock %}
+
+{% block content %}
+<h2 class="">Delete Event</h2>
+<div class="">
+    <form action="{% url 'delete-event' event.id %}" method="post">
+        <p class="">Are you sure you want to delete the event <span class="">"{{event.name}}"</span>?</p>
+        <div class="">
+            <button type="submit" class="">Delete</button>
+            <a href="{% url 'events' %}" class="">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/eventPlanner/planner/tests.py
+++ b/eventPlanner/planner/tests.py
@@ -1,3 +1,31 @@
 from django.test import TestCase
-
+from django.urls import reverse 
+from .models import Event
 # Create your tests here.
+
+class EventTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.event=Event.objects.create(
+            name='My event',
+            host='joe',
+            description='Event details',
+            location='Home'
+        )
+    
+    def test_event_model(self):
+        self.assertEqual(self.event.name, 'My event')
+        self.assertEqual(self.event.host,'joe')
+        self.assertEqual(self.event.description, 'Event details')
+        self.assertEqual(self.event.location, 'Home')
+
+    def test_delete_event(self):
+        response=self.client.post(reverse("delete-event", args="1"))
+        self.assertEqual(response.status_code, 302)
+        # self.assertTemplateUsed(response, "event_delete_confirm.html")
+
+    
+    
+
+
+    

--- a/eventPlanner/planner/urls.py
+++ b/eventPlanner/planner/urls.py
@@ -14,4 +14,7 @@ urlpatterns = [
     path('login', views.userLogin, name = 'loginPage'),
 
     path('signup', views.signup, name = 'signUp'),
+
+    # Delete event path
+    path('delete-event/<int:event_id>/', views.delete_event, name='delete-event'),
 ]

--- a/eventPlanner/planner/views.py
+++ b/eventPlanner/planner/views.py
@@ -1,11 +1,12 @@
-from django.shortcuts import render, HttpResponse, redirect
+from django.shortcuts import render, HttpResponse, redirect,get_object_or_404
 from .models import Event, RSVP, Task
 from .forms import RSVPForm
 from django.contrib.auth import authenticate
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
-
+# messages framework 
+from django.contrib import messages
 
 
 """
@@ -181,3 +182,26 @@ def signup(request):
         
 
 
+
+"""
+Delete Event 
+First get event by id using get_object_or_404() and render the event_confirm_delete.html template
+If the event does not exist, then redirect to a 404 page.
+Second , render the event_confirm_delete.html template if the HTTP request is GET
+Third, delete the event, create a flash message and redirects to the event list if the HTTP request is POST
+Bonus, Prevent a user from deleting event of other host by checking if the host of the event is the same as the currently logged user.
+If yes , we render delete form. otherwise we can redirect the users to a 404 page.
+"""
+
+@login_required
+def delete_event(request, event_id):
+    queryset=Event.objects.filter(host=request.user)
+    event=get_object_or_404(queryset, pk=event_id)
+    context={'event':event}
+    if request.method == 'GET':
+        return render(request, 'event_confirm_delete.html',context)
+    elif request.method == 'POST':
+        event.delete()
+        messages.success(request, 'The event has been deleted successfully')
+        
+        return redirect('events')


### PR DESCRIPTION
**Delete Event** 
First, get the event by id using get_object_or_404() and render the event_confirm_delete.html template
If the event does not exist, then redirect to a 404 page.
Second, render the event_confirm_delete.html template if the HTTP request is GET
Third, delete the event, create a flash message, and redirect to the event list if the HTTP request is POST
Bonus, Prevent a user from deleting an event of another host by checking if the event's host is the same as the currently logged user.
If yes, we render the delete form. otherwise, we can redirect the users to a 404 page.

**Delete View** 

![deleteview](https://github.com/mikeryu/westmont-cs130-f23-team-maroon/assets/143833326/7dac4670-3204-405a-8080-419d9d0502a6)

**Delete template form**

![delete](https://github.com/mikeryu/westmont-cs130-f23-team-maroon/assets/143833326/18da96cb-0966-403a-808e-a69b19385449)

**Delete Path Url**

![path](https://github.com/mikeryu/westmont-cs130-f23-team-maroon/assets/143833326/1eddaadb-0f83-4a9e-abb8-b7bebd439566)

**Flash Message** 

![message](https://github.com/mikeryu/westmont-cs130-f23-team-maroon/assets/143833326/73c58985-dc73-4bab-b28f-a95b0daca987)
