### PR TITLE
Cleaning grid

### DIFF
--- a/eventPlanner/planner/static/app.css
+++ b/eventPlanner/planner/static/app.css
@@ -25,3 +25,30 @@ body.background{
    }
 }
 
+
+.box {
+   height: 200px;
+}
+.box .title {
+   display: -webkit-box;
+   -webkit-line-clamp: 2;
+   -webkit-box-orient: vertical;
+   overflow: hidden;
+   text-overflow: ellipsis;
+}
+.box p.truncate-with-ellipsis {
+   display: -webkit-box;
+   -webkit-line-clamp: 1; 
+   -webkit-box-orient: vertical;
+   overflow: hidden;
+   text-overflow: ellipsis;
+}
+.box p.truncate-with-ellipsis2 {
+   display: -webkit-box;
+   -webkit-line-clamp: 2; 
+   -webkit-box-orient: vertical;
+   overflow: hidden;
+   text-overflow: ellipsis;
+}
+
+

--- a/eventPlanner/planner/templates/browseEvents.html
+++ b/eventPlanner/planner/templates/browseEvents.html
@@ -13,31 +13,6 @@
   </div>
 </section>
 
-<style>
-  .box {height: 200px;}
-  .box .title {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .box p.truncate-with-ellipsis {
-    display: -webkit-box;
-    -webkit-line-clamp: 1; 
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .box p.truncate-with-ellipsis2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2; 
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    }
-</style>
-
 <div class="container">
   <br>
   <div class="columns is-multiline">

--- a/eventPlanner/planner/templates/browseEvents.html
+++ b/eventPlanner/planner/templates/browseEvents.html
@@ -13,6 +13,31 @@
   </div>
 </section>
 
+<style>
+  .box {height: 200px;}
+  .box .title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .box p.truncate-with-ellipsis {
+    display: -webkit-box;
+    -webkit-line-clamp: 1; 
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .box p.truncate-with-ellipsis2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2; 
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    }
+</style>
+
 <div class="container">
   <br>
   <div class="columns is-multiline">
@@ -24,7 +49,13 @@
           <div class="tags">
             <span class="tag">{{event.location}}</span>
           </div>
-          <p>{{event.description}}</p>
+          {% if event.name|length < 26 %}
+            <p class="truncate-with-ellipsis2">{{event.description}}</p>
+          {% else %}
+            <p class="truncate-with-ellipsis">{{event.description}}</p>
+          {% endif %}
+
+          
         </div>
       </a>
     </div>

--- a/eventPlanner/planner/templates/createEvent.html
+++ b/eventPlanner/planner/templates/createEvent.html
@@ -24,7 +24,7 @@
       <div class="field">
         <label class="label">Name</label>
         <div class="control has-icons-left">
-          <input id="title" class="input is-rounded" type="text" placeholder="Event name" name="name" maxlength="250">
+          <input id="title" class="input is-rounded" type="text" placeholder="Event name" name="name" maxlength="250" required=True>
           <span class="icon is-small is-left">
             <i class="fas fa-flag"></i>
           </span>
@@ -34,8 +34,8 @@
       <div class="field">
         <label class="label">Host</label>
         <div class="control has-icons-left">
-          <input id="host" class="input is-rounded" type="text" placeholder="Enter your name" name="host"
-            maxlength="100">
+          <input id="host" class="input is-rounded" type="text" placeholder="Enter your name" name="host" 
+            maxlength="100" required=True>
           <span class="icon is-small is-left">
             <i class="fas fa-user"></i>
           </span>
@@ -50,7 +50,7 @@
         <label class="label">Location</label>
         <div class="control has-icons-left">
           <input id="location" class="input is-rounded" type="text" placeholder="Location" name="location"
-            maxlength="100">
+            maxlength="100" required=True>
           <span class="icon is-left">
             <i class="fa-solid fa-map-location-dot"></i>
           </span>
@@ -60,7 +60,7 @@
       <div class="field">
         <label class="label">Date</label>
         <div class="control has-icons-left">
-          <input class="input is-rounded" type="text" placeholder="Enter Date" name="date" maxlength="100">
+          <input class="input is-rounded" type="text" placeholder="Enter Date" name="date" maxlength="100" required=True>
           <span class="icon is-left">
             <i class="fa-solid fa-calendar-days"></i>
           </span>
@@ -70,7 +70,7 @@
       <div class="field">
         <label class="label">Time</label>
         <div class="control has-icons-left">
-          <input id="time" class="input is-rounded" type="text" placeholder="Enter Time" name="time" maxlength="100">
+          <input id="time" class="input is-rounded" type="text" placeholder="Enter Time" name="time" maxlength="100" required=True>
           <span class="icon is-left">
             <i class="fa-solid fa-clock"></i>
           </span>
@@ -83,7 +83,7 @@
         <label class="label">Description</label>
         <div class="control">
           <textarea id="description" class="textarea" placeholder="Describe your event." name="description"
-            maxlength="1000"></textarea>
+            maxlength="1000" required=True></textarea>
         </div>
       </div>
 

--- a/eventPlanner/planner/views.py
+++ b/eventPlanner/planner/views.py
@@ -58,7 +58,7 @@ def event(request, id):
             task = Task.objects.get(id=taskId)
         except Task.DoesNotExist:
             #if the tasks doesn't exist, we just assume the user is doing nothing for the event
-            task = Task(name = "do nothing", event  = Event.objects.get(id=id), completed = True)
+            task = Task(name = "only attend", event  = Event.objects.get(id=id), completed = True)
         task.completed = True
         task.save()
 

--- a/eventPlanner/planner/views.py
+++ b/eventPlanner/planner/views.py
@@ -119,8 +119,9 @@ def createEvent(request):
 
         #link all tasks to the event and save them
         for task in tasks:
-            newtask = Task(name=task, event=event)
-            newtask.save()
+            if len(task) > 0:
+                newtask = Task(name=task, event=event)
+                newtask.save()
  
         
         #Send the user to the browse events page


### PR DESCRIPTION
Text is limited now inside of the fixed box. Some things I would love feedback on: 
  I want the amount of lines displayed for event description to be dependent on the amount of lines that are displayed for the title (so if the title takes up 2 lines, the event details would only take up 1. But if the title only takes up one line, the event details can take up 2 lines). Right now it is dependent on the amount of characters in the title which does the job but isn't as consistent as I like. 
  I also am thinking about if we were to give every title 2 lines of space so the spacing would be the same on every event. Let me know what you think! 